### PR TITLE
x2projtool: Validate and update .x2proj file outside of build_common

### DIFF
--- a/x2projtool.ps1
+++ b/x2projtool.ps1
@@ -1,0 +1,181 @@
+Param(
+    [string]$projDirectory, # the path that contains the mod's .x2proj
+	[string]$subcommand, # one of `check`, `update`
+    [string[]] $ignoreOnDisk = "", # we pretend these files don't exist on disk
+    [string[]] $ignoreInProj = "" # we pretend we didn't see these files in the project
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0 | Out-Null
+
+function NormalizeAndFilter {
+    [CmdletBinding()]
+    param([string[]] $ToIgnore, [Parameter(ValueFromPipeline = $true)] $obj)
+    process {
+        $obj = $obj -Replace '/','\'
+        $obj = $obj -Replace '^\.\\'
+        #Write-Host "Checking $obj"
+        $ignored = @($ToIgnore | Where-Object -FilterScript { $obj -Match "^$($_)([\\]|$).*"}).Count -gt 0
+        if ($ignored) {
+            $obj = $null
+        }
+        $obj
+    }
+}
+
+class Tool {
+    [string] $projDirectory
+    [string] $projFile
+    [string] $namespace
+    [object] $nsmgr
+    [xml] $projXml
+
+    [string[]] $physFolders
+    [string[]] $physFiles
+
+    Tool(
+		[string]$projDirectory,
+        [string[]]$ignoreDisk
+	){
+		$this.projDirectory = $projDirectory
+
+        # Resolve-Path makes things relative with this
+        Push-Location $projDirectory | Out-Null
+
+        $this.physFolders = Get-ChildItem $projDirectory -directory -recurse |
+            Where-Object { (Get-ChildItem $_.fullName | Measure-Object).count -ne 0 } |
+            Select-Object -expandproperty FullName |
+            ForEach-Object { Resolve-Path -Relative $_ } |
+            NormalizeAndFilter -ToIgnore $ignoreDisk |
+            Sort-Object
+
+
+        $this.physFiles = Get-ChildItem $projDirectory -file -recurse -exclude "*.x2proj" |
+            Select-Object -expandproperty FullName |
+            ForEach-Object { Resolve-Path -Relative $_ } |
+            NormalizeAndFilter -ToIgnore $ignoreDisk |
+            Sort-Object
+
+        Pop-Location | Out-Null
+
+        $this.projFile = Get-ChildItem $projDirectory -file "*.x2proj" | Select-Object -ExpandProperty FullName
+
+        [xml]$this.projXml = Get-Content -Path $this.projFile
+        $this.nsmgr = [System.XML.XmlNamespaceManager]::new([System.XML.NameTable]::new())
+        $this.namespace = "http://schemas.microsoft.com/developer/msbuild/2003"
+        $this.nsmgr.AddNamespace("vs", $this.namespace) | Out-Null
+	}
+
+    [string[]]GetItemList($kind, $ignoreInProj) {
+        $xpath = "/vs:Project/vs:ItemGroup/vs:$($kind)"
+        $nodes = $this.projXml.SelectNodes($xpath, $this.nsmgr)
+        $items = $nodes |
+            ForEach-Object { $_.GetAttributeNode("Include").Value } |
+            NormalizeAndFilter $ignoreInProj |
+            Sort-Object
+        if ($kind -eq "Folder") {
+            $items = $items | ForEach-Object { $_ -Replace "\\$" }
+        }
+        return @($items)
+    }
+
+    [object]InsertItemList($kind, $list, $prev) {
+        $group = $this.projXml.CreateElement("ItemGroup", $this.namespace)
+        $list | ForEach-Object {
+            $folderElem = $this.projXml.CreateElement($kind, $this.namespace)
+            $attrib = $this.projXml.CreateAttribute("Include")
+            $attrib.Value = "$_"
+            $folderElem.Attributes.Append($attrib) | Out-Null
+            $group.AppendChild($folderElem) | Out-Null
+        }
+        $prev.ParentNode.InsertAfter($group, $prev) | Out-Null
+        return $group
+    }
+
+    [bool]RunDiff($disk, $proj, $kind) {
+        $diff = @(Compare-Object -ReferenceObject $disk -DifferenceObject $proj)
+        if ($diff.Count -gt 0) {
+            Write-Host -ForegroundColor Red "Error: The .x2proj file contains an incorrect $kind list."
+    
+            $left = @($diff | Where-Object -Property "SideIndicator" -EQ -Value "<=")
+            if ($left.Count -gt 0) {
+                Write-Host "The following $kind are only present in the project file:"
+                $left | ForEach-Object { Write-Host "    $($_.InputObject)" }
+            }
+    
+            $right = @($diff | Where-Object -Property "SideIndicator" -EQ -Value "=>")
+            if ($right.Count -gt 0) {
+                Write-Host "The following $kind are only present on disk:"
+                $right | ForEach-Object { Write-Host "    $($_.InputObject)" }
+            }
+            return $false
+        }
+        return $true
+    }
+}
+
+function Invoke-Check($projDirectory, $ignoreOnDisk, $ignoreInProj) {
+    $tool = [Tool]::new($projDirectory, $ignoreOnDisk)
+    $projFolders = $tool.GetItemList("Folder", $ignoreInProj)
+    $projFiles = $tool.GetItemList("Content", $ignoreInProj)
+
+    $ok = $tool.RunDiff($projFolders, $tool.physFolders, "folders")
+    $ok = $tool.RunDiff($projFiles, $tool.physFiles, "files") -and $ok
+
+    return $ok
+}
+
+function Invoke-Update($projDirectory, $ignoreOnDisk) {
+    $tool = [Tool]::new($projDirectory, $ignoreOnDisk)
+
+    $xpath = "/vs:Project/vs:ItemGroup"
+    $nodes = $tool.projXml.SelectNodes($xpath, $tool.nsmgr)
+    $nodes | ForEach-Object {
+        $_.ParentNode.RemoveChild($_) | Out-Null
+    }
+
+    $xpath = "/vs:Project/vs:PropertyGroup"
+    $prevNode = $tool.projXml.SelectNodes($xpath, $tool.nsmgr)[0]
+
+    # create folders
+    $prevNode = $tool.InsertItemList("Folder", $tool.physFolders, $prevNode)
+    # create files
+    $prevNode = $tool.InsertItemList("Content", $tool.physFiles, $prevNode)
+
+    # write to output
+    try
+    {
+        $ioWriter = [System.IO.StreamWriter]::new($tool.projFile)
+        $xmlWriter = [System.XMl.XmlTextWriter]::new($ioWriter)
+        $xmlWriter.Formatting = "indented" 
+        $xmlWriter.Indentation = 2
+        $tool.projXml.WriteContentTo($xmlWriter) 
+    }
+    finally
+    {
+        $ioWriter.close()
+    }
+}
+
+switch ($subcommand) {
+    "check" {
+        $ok = Invoke-Check $projDirectory $ignoreOnDisk $ignoreInProj
+        if (-not $ok) {
+            $host.SetShouldExit(1)
+            exit
+        }
+    }
+    "update" {
+        Invoke-Update $projDirectory $ignoreOnDisk
+        $ok = Invoke-Check $projDirectory $ignoreOnDisk $ignoreInProj
+        if (-not $ok) {
+            Write-Host -ForegroundColor Red "Error: Internal tool error: Checking the updated project file failed."
+            Write-Host -ForegroundColor Red "This is a bug in x2projtool. Please report it at:"
+            Write-Host "    https://github.com/X2CommunityCore/X2ModBuildCommon/issues/new"
+            $host.SetShouldExit(1)
+            exit
+        }
+    }
+    "" { throw "Missing subcommand" }
+    default { throw "Unknown command" }
+}


### PR DESCRIPTION
Current situation:

* Projects don't need ModBuddy or the `.x2proj` file, but a correct `.x2proj` file is needed for ModBuddy users
* There is a clear desire in some projects to keep this file up to date for that reason (`_ValidateProjectFiles`)
* `_ValidateProjectFiles` is buggy and doesn't catch folder renames, among other things
* Projects where none of the maintainers use ModBuddy (e.g. lwotc) disable `_ValidateProjectFiles` and the `.x2proj` file quickly deteriorates to the point where it is not usable with ModBuddy.

This tool:

* Can validate the `.x2proj` file for correctness (e.g. CI)
* Can keep an `.x2proj` file in sync with the actual filesystem
* Has two ignore lists, one to ignore present root directories in the project filesystem (CI excludes Content) and one to ignore root directories that exist in the project file but not on disk (Lwotc commits only part of its content)
* Keeps file lists sorted

<details><summary>Example output of `check` in various projects: (click to expand)</summary>

CHL:
```
PS D:\X2ModBuildCommon> powershell.exe -NonInteractive -ExecutionPolicy Unrestricted -file '.\x2projtool.ps1' -projDirectory "$($env:USERPROFILE)\Documents\FiraxisModBuddy\XCOM\X2WOTCCommunityHighlander\X2WOTCCommunityHighlander" -subcommand "check"

Error: The .x2proj file contains an incorrect files list.
The following files are only present on disk:
    ModPreviewBeta.jpg
    ReadMe.txt
```

CI:
```
PS D:\X2ModBuildCommon> powershell '.\x2projtool.ps1' -projDirectory "$($env:USERPROFILE)\Documents\FiraxisModBuddy\XCOM\CovertInfiltration\CovertInfiltration" -subcommand "check" -ignoreOnDisk "Content,ContentForCook,CookedPCConsole"

Error: The .x2proj file contains an incorrect folders list.
The following folders are only present in the project file:
    Content
```


LWOTC:
```
PS D:\X2ModBuildCommon> powershell '.\x2projtool.ps1' -projDirectory "$($env:USERPROFILE)\Documents\FiraxisModBuddy\XCOM\lwotc\LongWarOfTheChosen" -subcommand "check" -ignoreOnDisk "Content" -ignoreInProj "Content"

Error: The .x2proj file contains an incorrect folders list.
The following folders are only present in the project file:
    Localization\DetailedSoldierListWOTC_Integrated
    Src\DetailedSoldierListWOTC_Integrated
    Src\DetailedSoldierListWOTC_Integrated\Classes
The following folders are only present on disk:
    Localization\LW_WeaponsAndArmor
    Src\LW_Tutorial
Error: The .x2proj file contains an incorrect files list.
The following files are only present in the project file:
    Localization\DetailedSoldierListWOTC_Integrated\DetailedSoldierListWOTC_Integrated.fra
    Localization\DetailedSoldierListWOTC_Integrated\DetailedSoldierListWOTC_Integrated.INT
    Src\DetailedSoldierListWOTC_Integrated\Classes\MoreDetailsManager.uc
    Src\DetailedSoldierListWOTC_Integrated\Classes\MoreDetailsNavigatorWrapper.uc
    Src\DetailedSoldierListWOTC_Integrated\Classes\UIPersonnel_SoldierListItemDetailed.uc
    Src\DetailedSoldierListWOTC_Integrated\Classes\X2DownloadableContentInfo_DetailedSoldierListWOTC.uc
    Src\LW_FactionBalance\Classes\XMBEffect_AddAbilityCharges.uc
    Src\LW_FactionBalance\Classes\XMBEffect_RevealUnit_LW.uc
    Src\LW_FactionBalance\Classes\XMBEffectUtilities.uc
    Src\LW_Overhaul\Classes\LWXComGameVersion.uc
    Src\LW_Overhaul\Classes\LWXComGameVersionTemplate.uc
    Src\LW_Overhaul\Classes\X2AbilityCooldown_Shared.uc
    Src\LW_Overhaul\Classes\X2Condition_TargetHasOneOfTheEffects.uc
    Src\LW_Overhaul\Classes\X2Effect_AddAmmo.uc
    Src\LW_Overhaul\Classes\X2Effect_BloodThirst.uc
    Src\LW_Overhaul\Classes\X2Effect_Fatality_LW.uc
    Src\LW_Overhaul\Classes\X2Effect_LWHolotarget.uc
    Src\LW_Overhaul\Classes\X2StatusEffects_LW.uc
The following files are only present on disk:
    Localization\LW_FactionBalance\XComGame.fra
    Localization\LW_FactionBalance\XComGame.rus
    Localization\LW_WeaponsAndArmor\XComGame.fra
    Localization\LW_WeaponsAndArmor\XComGame.int
    Localization\LW_WeaponsAndArmor\XComGame.rus
    Localization\NewPromotionScreenByDefault_Integrated\XComGame.fra
    Localization\NewPromotionScreenByDefault_Integrated\XComGame.int
    ModPreview.jpg
    ReadMe.txt
    Src\LW_PerkPack_Integrated\Classes\X2AbilityCooldown_Shared.uc
    Src\LW_PerkPack_Integrated\Classes\X2Condition_TargetHasOneOfTheEffects.uc
    Src\LW_PerkPack_Integrated\Classes\X2Effect_AddAmmo.uc
    Src\LW_PerkPack_Integrated\Classes\X2Effect_BloodThirst.uc
    Src\LW_PerkPack_Integrated\Classes\X2Effect_Fatality_LW.uc
    Src\LW_PerkPack_Integrated\Classes\X2Effect_LWHolotarget.uc
    Src\LW_PerkPack_Integrated\Classes\X2StatusEffects_LW.uc
    Src\LW_PerkPack_Integrated\Classes\XMBEffect_RevealUnit_LW.uc
    Src\LW_XModBase\Classes\XMBEffect_AddAbilityCharges.uc
    Src\LW_XModBase\Classes\XMBEffectUtilities.uc
```
</details>

Quick diffs of the project files with `update` (will outdate with changes made here, read discussion for updates): https://gist.github.com/robojumper/dd360bfbe9798ab6f57026e780278e25