### PR TITLE
Fix build error when cooking maps

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -611,7 +611,7 @@ class BuildProject {
 			$sfMapsNames = @(Get-ChildItem -Path "$contentForCookPath/Maps" -Recurse -Include *.umap | ForEach-Object { $_.BaseName })
 
 			# Allow using the force-package-into-map functionality for non-empty maps
-			$sfCollectionOnlyMapsNames = $sfCollectionOnlyMapsNames | Where-Object { $sfMapsNames -notcontains $_ }
+			$sfCollectionOnlyMapsNames = @($sfCollectionOnlyMapsNames | Where-Object { $sfMapsNames -notcontains $_ })
 		}
 
 		if (Test-Path "$contentForCookPath/Standalone") {


### PR DESCRIPTION
`sfCollectionOnlyMapNames` was being overwritten with a potentially null value if there were maps in 'ContentForCook/Maps'. This wraps the right-hand expression with `@()` to ensure the null value is converted to an empty array.

Fixes #50.