### PR TITLE
Fix erroneous logic test on collection maps

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -599,7 +599,7 @@ class BuildProject {
 		$sfMapsNames = @()
 
 		if (-not(Test-Path $contentForCookPath)) {
-			if ($sfCollectionOnlyMapsNames.Length -lt 1) {
+			if ($sfCollectionOnlyMapsNames.Length -gt 0) {
 				ThrowFailure "Collection map cooking is requested, but no ContentForCook folder is present"
 			}
 


### PR DESCRIPTION
A test for whether the collection maps configuration specified at least one map to cook was instead checking if there were *no* maps configured.