### PR TITLE
Don't crash on cross-platform pwsh when playing build status sounds

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -154,7 +154,7 @@ class BuildProject {
 			SuccessMessage "*** SUCCESS! ($(FormatElapsed $fullStopwatch.Elapsed)) ***" $this.modNameCanonical
 		}
 		catch {
-			[System.Media.SystemSounds]::Hand.Play()
+			try { [System.Media.SystemSounds]::Hand.Play() } catch {}
 			throw
 		}
 	}
@@ -1537,7 +1537,7 @@ class ModcookReceiver : StdoutReceiver {
 
 function FailureMessage($message)
 {
-	[System.Media.SystemSounds]::Hand.Play()
+	try { [System.Media.SystemSounds]::Hand.Play() } catch {}
 	Write-Host $message -ForegroundColor "Red"
 }
 
@@ -1548,7 +1548,7 @@ function ThrowFailure($message)
 
 function SuccessMessage($message, $modNameCanonical)
 {
-	[System.Media.SystemSounds]::Asterisk.Play()
+	try { [System.Media.SystemSounds]::Asterisk.Play() } catch {}
 	Write-Host $message -ForegroundColor "Green"
 	Write-Host "$modNameCanonical ready to run." -ForegroundColor "Green"
 }


### PR DESCRIPTION
[System.Media.SystemSounds]::*.Play() needs System.Windows.Extensions, which isn't available on cross-platform pwsh (only Windows PowerShell 5.1). One of the three call sites sits inside the build's own top-level catch block, so the resulting PlatformNotSupportedException replaced the real success/failure message instead of just failing to play a sound. Swallow the exception at each call site instead of removing the sound outright, so it still plays normally under Windows PowerShell.