### PR TITLE
Fix modScriptPackages holding full paths instead of package names

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -240,7 +240,7 @@ class BuildProject {
 		# the mod's packages
 		$modSrcPath = "$($this.modSrcRoot)/Src"
 		if (Test-Path $modSrcPath) {
-			$this.modScriptPackages = @(Get-ChildItem "$($this.modSrcRoot)/Src" -Directory)
+			$this.modScriptPackages = @((Get-ChildItem "$($this.modSrcRoot)/Src" -Directory).Name)
 		} else {
 			# No scripts to compile
 			$this.modScriptPackages = @()


### PR DESCRIPTION
$this.modScriptPackages is typed [string[]], but was assigned the raw Get-ChildItem -Directory results (DirectoryInfo objects). PowerShell coerces each to its full path via ToString(), not just the folder name, so every later "$name.u" package-copy step built a garbage path. Platform-independent bug, not Linux-specific.