### PR TITLE
Quote Robocopy wildcard patterns

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -348,7 +348,7 @@ class BuildProject {
 		}
 		
 		Write-Host "Copying mod project to staging..."
-		Robocopy.exe "$($this.modSrcRoot)" "$($this.stagingPath)" *.* $global:def_robocopy_args /XF @xf /XD "ContentForCook"
+		Robocopy.exe "$($this.modSrcRoot)" "$($this.stagingPath)" "*.*" $global:def_robocopy_args /XF @xf /XD "ContentForCook"
 		Write-Host "Copied project to staging."
 
 		if ($this._HasScriptPackages()) {
@@ -401,7 +401,7 @@ class BuildProject {
 	[void]_CopyToSrc() {
 		# mirror the SDK's SrcOrig to its Src
 		Write-Host "Mirroring SrcOrig to Src..."
-		Robocopy.exe "$($this.sdkPath)\Development\SrcOrig" "$($this.devSrcRoot)" *.uc *.uci $global:def_robocopy_args
+		Robocopy.exe "$($this.sdkPath)\Development\SrcOrig" "$($this.devSrcRoot)" "*.uc" "*.uci" $global:def_robocopy_args
 		Write-Host "Mirrored SrcOrig to Src."
 
 		$this._ParseMacroFile("$($this.devSrcRoot)\Core\Globals.uci")
@@ -707,7 +707,7 @@ class BuildProject {
 		# Ideally, the cooking process wouldn't modify the big *.tfc files, but it does, so we don't overwrite existing ones (/XC /XN /XO)
 		# In order to "reset" the cooking direcory, just delete it and let the script recreate them
 		Write-Host "Copying Texture File Caches..."
-		Robocopy.exe "$cookedpcconsoledir" "$($this.cookerOutputPath)" *.tfc /NJH /XC /XN /XO
+		Robocopy.exe "$cookedpcconsoledir" "$($this.cookerOutputPath)" "*.tfc" /NJH /XC /XN /XO
 		Write-Host "Copied Texture File Caches."
 		
 		# Prepare editor args
@@ -764,7 +764,7 @@ class BuildProject {
 	[void]_FinalCopy() {
 		# copy all staged files to the actual game's mods folder
 		# TODO: Is the string interpolation required in the robocopy calls?
-		Robocopy.exe "$($this.stagingPath)" "$($this.finalModPath)" *.* $global:def_robocopy_args
+		Robocopy.exe "$($this.stagingPath)" "$($this.finalModPath)" "*.*" $global:def_robocopy_args
 	}
 
 	[string[]] _PrepareBuildCacheEngineIniWithAdditions ([string] $fileNamePrefix, [array] $lines) {


### PR DESCRIPTION
Cross-platform pwsh (unlike Windows PowerShell 5.1) expands a bare wildcard token against the current directory when calling a native command, if anything there matches. Quoting each pattern stops pwsh from ever globbing them, matching Robocopy's own literal-pattern semantics.