### PR TITLE
Pass -unattended to every commandlet invocation

### DIFF
--- a/build_common.ps1
+++ b/build_common.ps1
@@ -564,7 +564,7 @@ class BuildProject {
 
 	[void]_RunMakeMod() {
 		# build the mod's scripts
-		$scriptsMakeArguments = "make -nopause -mods $($this.modNameCanonical) $($this.stagingPath)"
+		$scriptsMakeArguments = "make -nopause -unattended -mods $($this.modNameCanonical) $($this.stagingPath)"
 		if ($this.debug -eq $true)
 		{
 			$scriptsMakeArguments = "$scriptsMakeArguments -debug"
@@ -718,7 +718,7 @@ class BuildProject {
 		Write-Host "Copied Texture File Caches."
 		
 		# Prepare editor args
-		$cook_args = @("cookpackages", "-platform=pcconsole", "-quickanddirty", "-modcook", "-sha", "-multilanguagecook=INT+FRA+ITA+DEU+RUS+POL+KOR+ESN", "-singlethread", "-nopause")
+		$cook_args = @("cookpackages", "-platform=pcconsole", "-quickanddirty", "-modcook", "-sha", "-multilanguagecook=INT+FRA+ITA+DEU+RUS+POL+KOR+ESN", "-singlethread", "-nopause", "-unattended")
 		if ($this.final_release -eq $true)
 		{
 			$cook_args += "-final_release"


### PR DESCRIPTION
_RunMakeBase() already passed -unattended, but _RunMakeMod() and
_RunCookHL() didn't. Without it, the commandlet host might show an
interactive "Scripts are outdated. Would you like to rebuild now?"
dialog that blocks the build until a human clicks "No". -unattended
suppresses this dialog.

Note, though, that we shouldn't pass -unattended to precompileshaders,
because that causes it to crash due to a bug in Firaxis's code. There is
nothing we can do about that on our side.
