### PR TITLE
Make clean.ps1 usable without a mod name for a general clean

### DIFF
--- a/clean.ps1
+++ b/clean.ps1
@@ -1,5 +1,5 @@
 Param(
-    [string] $modName, # mod folder name
+    [string] $modName, # mod folder name -- omit (together with $srcDirectory) for a general clean not scoped to any one mod
     [string] $srcDirectory, # the path that contains your mod's .XCOM_sln
     [string] $sdkPath, # the path to your SDK installation ending in "XCOM 2 War of the Chosen SDK"
     [string] $gamePath # the path to your XCOM 2 installation ending in "XCOM2-WaroftheChosen"
@@ -13,15 +13,7 @@ $cleanCookerOutput = Join-Path -Path $scriptDirectory "clean_cooker_output.ps1"
 Write-Host "Sourcing $cleanCookerOutput"
 . $cleanCookerOutput
 
-if ($null -eq $modName -or $modName -eq "") {
-    throw "`$modName empty???"
-}
-
 Write-Host "Deleting all cached build artifacts..."
-
-# This needs to be before $srcDirectory\BuildCache is deleted - otherwise we will miss our collection maps
-# This is dumb, yes, but to fix this we need to rework how BuildProject is used from build.ps1 (and here)
-CleanModAssetCookerOutput $sdkPath $modName @("$srcDirectory\$modName\ContentForCook", "$srcDirectory\BuildCache\CollectionMaps")
 
 $files = @(
     "$sdkPath\XComGame\lastBuildDetails.json",
@@ -31,11 +23,18 @@ $files = @(
 )
 
 $folders = @(
-    "$srcDirectory\BuildCache",
     "$sdkPath\Development\Src\*",
-    "$sdkPath\XComGame\Mods\*",
-    "$gamePath\XComGame\Mods\$modName"
+    "$sdkPath\XComGame\Mods\*"
 )
+
+if ($modName) {
+    # This needs to be before $srcDirectory\BuildCache is deleted - otherwise we will miss our collection maps
+    # This is dumb, yes, but to fix this we need to rework how BuildProject is used from build.ps1 (and here)
+    CleanModAssetCookerOutput $sdkPath $modName @("$srcDirectory\$modName\ContentForCook", "$srcDirectory\BuildCache\CollectionMaps")
+
+    $folders += "$srcDirectory\BuildCache"
+    $folders += "$gamePath\XComGame\Mods\$modName"
+}
 
 $files | ForEach-Object {
     Write-Host "Removing file(s) $($_)"
@@ -47,6 +46,8 @@ $folders | ForEach-Object {
     Remove-Item -Recurse -Force $_ -WarningAction SilentlyContinue -ErrorAction SilentlyContinue
 }
 
-TryCleanHlCookerOutput $sdkPath "$srcDirectory\$modName\Src"
+if ($modName) {
+    TryCleanHlCookerOutput $sdkPath "$srcDirectory\$modName\Src"
+}
 
 Write-Host "Cleaned."


### PR DESCRIPTION
$modName was required for the entire script, throwing if empty -- but only four steps (CleanModAssetCookerOutput, the srcDirectory BuildCache and game Mods folder entries, TryCleanHlCookerOutput) actually need a mod to scope them to; everything else doesn't. Drop the throw and skip just those steps when $modName is empty, so callers can invoke a general clean (SDK Development/Src, XComGame/Mods, lastBuildDetails.json, etc.) without targeting any one mod.